### PR TITLE
Add babel-cli as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/Builtvisible/history-of-humanity",
   "devDependencies": {
+    "babel-cli": "^6.22.2",
     "browserify": "^12.x.x",
     "uglifyify": "3.0.x"
   },


### PR DESCRIPTION
Nothing too special here, this *PR* basically adds `babel-cli` as a dependency–which prevents it from telling us that:

> You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package.
>
>    npm uninstall babel
>    npm install babel-cli
>
> See http://babeljs.io/docs/usage/cli/ for setup instructions.

As you can see here:

<img width="1102" alt="captura de tela 2017-01-25 as 02 05 15" src="https://cloud.githubusercontent.com/assets/2644563/22277593/f560d61e-e2a3-11e6-9e30-b0e5d03e40ee.png">
